### PR TITLE
allow empty postal code

### DIFF
--- a/lib/ups/builders/address_builder.rb
+++ b/lib/ups/builders/address_builder.rb
@@ -102,7 +102,8 @@ module UPS
       #
       # @return [Ox::Element] XML representation of the postal_code address part
       def postal_code
-        element_with_value('PostalCode', opts[:postal_code][0..9])
+        data = opts.fetch(:postal_code, '')[0..9]
+        element_with_value('PostalCode', data)
       end
 
       # Returns an XML representation of country

--- a/spec/ups/builders/address_builder_minitest_spec.rb
+++ b/spec/ups/builders/address_builder_minitest_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+class UPS::Builders::TestAddressBuilder < Minitest::Test
+  include SchemaPath
+  include ShippingOptions
+
+  def setup
+    @us_address_builder = UPS::Builders::AddressBuilder.new({country: 'us', state: 'ny', postal_code: '29464'})
+    @ie_address_builder = UPS::Builders::AddressBuilder.new({country: 'ie', state: 'galway', postal_code: ''})
+  end
+
+  def test_allows_postal_code
+    assert_equal(@us_address_builder.postal_code.text, "29464")
+  end
+
+  def test_allows_empty_postal_code
+    assert_equal(@ie_address_builder.postal_code.text, "")
+  end
+end


### PR DESCRIPTION
UPS doesn't appear to require postal codes for lots of countries, including Ireland, so this code should not break if a nil or empty string is passed in as a value for postal code. address validation for the postal code should be handled elsewhere.

<img width="1165" alt="screen shot 2019-01-08 at 3 34 18 pm" src="https://user-images.githubusercontent.com/608048/50857204-efa40900-135a-11e9-9b61-9964eb5b16db.png">
<img width="1212" alt="screen shot 2019-01-08 at 3 33 58 pm" src="https://user-images.githubusercontent.com/608048/50857212-f3379000-135a-11e9-83a5-28dfc0d68bbd.png">

https://www.ups.com/worldshiphelp/WS19/ENU/AppHelp/SHIPMENT/Country_Territory_Postal_Code_and_State_Prov_Guidelines_Popup.htm

https://www.ups.com/worldshiphelp/WS19/ENU/AppHelp/Codes/Countries_Territories_Requiring_Postal_Codes.htm

### testing note: 
I had to run my spec like `bundle exec ruby -Ilib -Ispec spec/ups/builders/address_builder_minitest_spec.rb ` to include the spec_helper