### PR TITLE
make sure nil allowed for postal code address also

### DIFF
--- a/lib/ups/builders/address_builder.rb
+++ b/lib/ups/builders/address_builder.rb
@@ -102,8 +102,8 @@ module UPS
       #
       # @return [Ox::Element] XML representation of the postal_code address part
       def postal_code
-        data = opts.fetch(:postal_code, '')[0..9]
-        element_with_value('PostalCode', data)
+        data_string = opts.fetch(:postal_code, nil) || ""
+        element_with_value('PostalCode', data_string[0..9])
       end
 
       # Returns an XML representation of country

--- a/spec/ups/builders/address_builder_minitest_spec.rb
+++ b/spec/ups/builders/address_builder_minitest_spec.rb
@@ -7,6 +7,7 @@ class UPS::Builders::TestAddressBuilder < Minitest::Test
   def setup
     @us_address_builder = UPS::Builders::AddressBuilder.new({country: 'us', state: 'ny', postal_code: '29464'})
     @ie_address_builder = UPS::Builders::AddressBuilder.new({country: 'ie', state: 'galway', postal_code: ''})
+    @hk_address_builder = UPS::Builders::AddressBuilder.new({country: 'hk', state: '', postal_code: nil })
   end
 
   def test_allows_postal_code
@@ -16,4 +17,9 @@ class UPS::Builders::TestAddressBuilder < Minitest::Test
   def test_allows_empty_postal_code
     assert_equal(@ie_address_builder.postal_code.text, "")
   end
+
+  def test_allows_nil_postal_code
+    assert_equal(@hk_address_builder.postal_code.text, "")
+  end
+
 end


### PR DESCRIPTION
addition to https://github.com/sellect/ups-ruby/pull/2 (`v0.9.8`)

addresses new issue: 
https://github.com/kingandpartners/elietahari/issues/6754
https://github.com/kingandpartners/elietahari/issues/6722


```
irb(main):012:0> a = o.shipping_address
=> #<Sellect::Address id: 236240, first_name: "Leung", last_name: "Lana", address1: "7-9 Macdonnell Road", address2: "9th Floor, Hoover Court", city: "Hong Kong", zipcode: nil, phone: "94811388", state_name: "", country_id: 89, created_at: "2019-02-16 09:41:20", updated_at: "2019-02-16 09:42:14", user_id: 93983, primary_billing: false, primary_shipping: false, deleted_at: nil, locked: true, order_id: 47741644, primary_default: false, published: true, nickname: nil, tax_line: nil>
irb(main):013:0> ap a
Leung Lana: 7-9 Macdonnell Road {
                  :id => 236240,
          :first_name => "Leung",
           :last_name => "Lana",
            :address1 => "7-9 Macdonnell Road",
            :address2 => "9th Floor, Hoover Court",
                :city => "Hong Kong",
             :zipcode => nil,
               :phone => "94811388",
          :state_name => "",
          :country_id => 89,
          :created_at => Sat, 16 Feb 2019 04:41:20 EST -05:00,
          :updated_at => Sat, 16 Feb 2019 04:42:14 EST -05:00,
             :user_id => 93983,
     :primary_billing => false,
    :primary_shipping => false,
          :deleted_at => nil,
              :locked => true,
            :order_id => 47741644,
     :primary_default => false,
           :published => true,
            :nickname => nil,
            :tax_line => nil
}
```