### PR TITLE
initial work to add reference numbers to shipment or package

### DIFF
--- a/lib/ups/builders/builder_base.rb
+++ b/lib/ups/builders/builder_base.rb
@@ -148,6 +148,8 @@ module UPS
           org << element_with_value('Description', 'Rate')
           org << package_weight(opts[:weight], opts[:unit])
           org << package_dimensions(opts[:dimensions]) if opts[:dimensions]
+
+          add_reference_numbers_to_root(org, opts[:reference_numbers])
         end
       end
 
@@ -210,6 +212,25 @@ module UPS
           org << element_with_value('Width', dimensions[:width].to_s[0..8])
           org << element_with_value('Height', dimensions[:height].to_s[0..8])
         end
+      end
+
+      def add_reference_numbers_to_root(root, opts = [])
+        return if opts.nil? || opts.empty?
+        fail InvalidAttributeError, :reference_numbers unless opts.is_a?(Array)
+
+        opts.each do |ref|
+          add_reference_number(root, ref)
+        end
+      end
+
+      def add_reference_number(parent_root, opts = {})
+        parent_root << reference_number(opts[:code], opts[:value])
+      end
+
+      def reference_number(code, value)
+        multi_valued('ReferenceNumber',
+                     'Code' => code.to_s,
+                     'Value' => value.to_s)
       end
 
       def unit_of_measurement(unit)

--- a/lib/ups/builders/ship_confirm_builder.rb
+++ b/lib/ups/builders/ship_confirm_builder.rb
@@ -66,13 +66,13 @@ module UPS
 
       # Adds ReferenceNumber to the XML document being built
       #
-      # @param [Hash] opts A Hash of data to build the requested section
+      # @param [Hash] opts An Array of Hashes of data to build the requested section
       # @option opts [String] :code Code
       # @option opts [String] :value Value
       #
       # @return [void]
-      def add_reference_number(opts = {})
-        shipment_root << reference_number(opts[:code], opts[:value])
+      def add_reference_numbers(opts = [])
+        add_reference_numbers_to_root(shipment_root, opts)
       end
 
       private
@@ -101,12 +101,6 @@ module UPS
         multi_valued('LabelStockSize',
                      'Height' => size[:height].to_s,
                      'Width' => size[:width].to_s)
-      end
-
-      def reference_number(code, value)
-        multi_valued('ReferenceNumber',
-                     'Code' => code.to_s,
-                     'Value' => value.to_s)
       end
     end
   end

--- a/spec/ups/builders/ship_confirm_builder_spec.rb
+++ b/spec/ups/builders/ship_confirm_builder_spec.rb
@@ -14,7 +14,7 @@ class UPS::Builders::TestShipConfirmBuilder < Minitest::Test
       builder.add_label_specification 'gif', { height: '100', width: '100' }
       builder.add_international_invoice invoice_form
       builder.add_description 'Los Pollo Hermanos'
-      builder.add_reference_number reference_number
+      builder.add_reference_numbers [reference_number]
       builder.add_insurance_charge '5.00'
     end
   end


### PR DESCRIPTION
- UPS api changed so multiple reference numbers can be added but they
can only added to shipment for international orders, and only added to
package for US to US or PR to PR orders

built to address kingandpartners/elietahari#6990